### PR TITLE
Better handling of double-float infinities for Lispworks.

### DIFF
--- a/src/formats/text/text.lisp
+++ b/src/formats/text/text.lisp
@@ -5,10 +5,10 @@
 (defmethod catch-strange-float (value)
   value)
 
-(defmethod catch-strange-float ((value (eql #+sbcl sb-ext:double-float-positive-infinity #+(and ecl ieee-floating-point) EXT:DOUBLE-FLOAT-POSITIVE-INFINITY)))
+(defmethod catch-strange-float ((value (eql #+sbcl sb-ext:double-float-positive-infinity #+(and ecl ieee-floating-point) EXT:DOUBLE-FLOAT-POSITIVE-INFINITY #+lispworks +1D++0)))
   "+Inf")
 
-(defmethod catch-strange-float ((value (eql #+sbcl sb-ext:double-float-negative-infinity #+(and ecl ieee-floating-point) EXT:DOUBLE-FLOAT-negative-INFINITY)))
+(defmethod catch-strange-float ((value (eql #+sbcl sb-ext:double-float-negative-infinity #+(and ecl ieee-floating-point) EXT:DOUBLE-FLOAT-NEGATIVE-INFINITY #+lispworks -1D++0)))
   "-Inf")
 
 (defun print-sample-line (stream name lables lvalues value)

--- a/src/prometheus/metrics/histogram.lisp
+++ b/src/prometheus/metrics/histogram.lisp
@@ -31,7 +31,7 @@
   (unless (equalp (sort (copy-seq buckets) #'<) buckets)
     (error 'invalid-buckets-error :value buckets :reason "bounds not sorted"))
 
-  (let ((with+inf (make-array (1+ (length buckets)) :element-type 'number :initial-element #+allegro excl::*infinity-double* #+lispworks #.(read-from-string "10E999") #+sbcl sb-ext:double-float-positive-infinity #+(and ecl ieee-floating-point) EXT:DOUBLE-FLOAT-POSITIVE-INFINITY)))
+  (let ((with+inf (make-array (1+ (length buckets)) :element-type 'number :initial-element #+allegro excl::*infinity-double* #+lispworks 1D++0 #+sbcl sb-ext:double-float-positive-infinity #+(and ecl ieee-floating-point) EXT:DOUBLE-FLOAT-POSITIVE-INFINITY)))
     (replace with+inf buckets)
     with+inf))
 


### PR DESCRIPTION
Lispworks has special syntax for infinities (-1f++0, 1f++0, -1d++0, 1d++0).