### PR TITLE
Make generate-exponential-buckets assertions consistent

### DIFF
--- a/src/prometheus/buckets.lisp
+++ b/src/prometheus/buckets.lisp
@@ -14,7 +14,7 @@
                                                  (incf start step)))))
 
 (defun generate-exponential-buckets (start factor count)
-  (assert (> count 1) (count) 'invalid-value-error :value count :reason "buckets count should be positive")
+  (assert (> count 1) (count) 'invalid-value-error :value count :reason "buckets count should be greater than 1")
   (assert (> start 0) (start) 'invalid-value-error :value start :reason "buckets start should be positive")
   (assert (> factor 1) (factor) 'invalid-value-error :value factor :reason "buckets factor should be greater than 1")
 


### PR DESCRIPTION
This PR alters the assertion message for `generate-exponential-buckets` to match other assertions with similar checks. Admittedly, I'm not sure if this should be `> count 0` instead, so if that's the appropriate fix please let me know!