### PR TITLE
Make prometheus.collectors.process system definition depends on cffi-grovel

### DIFF
--- a/prometheus.collectors.process.asd
+++ b/prometheus.collectors.process.asd
@@ -5,6 +5,7 @@
   :serial t
   :version "0.1"
   :licence "MIT"
+  :defsystem-depends-on ("cffi-grovel")
   :depends-on ("prometheus"
                "cl-fad"
                "split-sequence"


### PR DESCRIPTION
Otherwise, it can't be loaded because cffi-grovel might be missing at the moment when prometheus.collectors.process is compiled.